### PR TITLE
Allow including multiple modules

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -20,8 +20,10 @@ define hp_sdr::repo (
     fail("Invalid ensure state: ${ensure}")
   }
 
-  class { 'hp_sdr::keys':
-    stage => $keys_stage,
+  if ! defined( Class['hp_sdr::keys'] ) {
+    class { 'hp_sdr::keys':
+      stage => $keys_stage,
+    }
   }
 
   $_url = inline_template("${url_base}/${url_repo}")


### PR DESCRIPTION
This fixes an error in case for example hp_sdr::spp and hp_sdr::hpsum are included:

Duplicate declaration: Class[Hp_sdr::Keys] is already declared in file modules/hp_sdr/manifests/repo.pp:25;
cannot redeclare at modules/hp_sdr/manifests/repo.pp:25 on node