### PR TITLE
update puppetlabs-apt to >=2.0.0

### DIFF
--- a/manifests/keys.pp
+++ b/manifests/keys.pp
@@ -33,18 +33,18 @@ class hp_sdr::keys (
 
     debian,ubuntu: {
       apt::key { 'hpPublicKey1':
-        key         => $gpg_key1_id,
-        key_content => $gpg_key1,
+        id      => $gpg_key1_id,
+        content => $gpg_key1,
       }
 
       apt::key { 'hpPublicKey2':
-        key         => $gpg_key2_id,
-        key_content => $gpg_key2,
+        id      => $gpg_key2_id,
+        content => $gpg_key2,
       }
 
       apt::key { 'hpPublicKey3':
-        key         => $gpg_key3_id,
-        key_content => $gpg_key3,
+        id      => $gpg_key3_id,
+        content => $gpg_key3,
       }
     }
 

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -60,12 +60,11 @@ define hp_sdr::repo (
 
     debian: {
       apt::source { $_name:
-        ensure      => $ensure,
-        location    => $_url,
-        release     => "${release}/${project_ver}",
-        repos       => 'non-free',
-        include_src => false,
-        require     => Class['hp_sdr::keys'],
+        ensure   => $ensure,
+        location => $_url,
+        release  => "${release}/${project_ver}",
+        repos    => 'non-free',
+        require  => Class['hp_sdr::keys'],
       }
     }
 

--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,7 @@
   "issues_url": "https://github.com/vholer/puppet-hp_sdr/issues",
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.0.0"},
-    {"name":"puppetlabs/apt","version_requirement":">= 1.6.0"},
+    {"name":"puppetlabs/apt","version_requirement":">= 2.0.0"},
     {"name":"ceritsc/yum","version_requirement":">= 0.9.0"},
     {"name":"darin/zypprepo","version_requirement":">= 1.0.1"}
   ],


### PR DESCRIPTION
This removes deprecation warnings if you use puppetlabs-apt >=2.0.0